### PR TITLE
Specify license on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/component/escape-html.git"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
By specifying the license on `package.json`, then automated tools such as https://github.com/pivotal/LicenseFinder can easily display which license your module is using.