### PR TITLE
Optimize

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 /*!
  * escape-html
  * Copyright(c) 2012-2013 TJ Holowaychuk
+ * Copyright(c) 2015 Andreas Lubbe
+ * Copyright(c) 2015 Tiancheng "Timothy" Gu
  * MIT Licensed
  */
 
@@ -11,6 +13,8 @@
 
 module.exports = escapeHtml;
 
+var matchHtml = /["'&<>]/;
+
 /**
  * Escape special characters in the given string of html.
  *
@@ -20,10 +24,25 @@ module.exports = escapeHtml;
  */
 
 function escapeHtml(html) {
-  return String(html)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+  html = '' + html;
+  var regexResult = matchHtml.exec(html);
+  if (!regexResult) return html;
+
+  var result = '';
+  var i, lastIndex = 0, escape;
+  for (i = regexResult.index; i < html.length; i++) {
+    switch (html.charCodeAt(i)) {
+      case 34: escape = '&quot;'; break;
+      case 39: escape = '&#39;';  break;
+      case 38: escape = '&amp;';  break;
+      case 60: escape = '&lt;';   break;
+      case 62: escape = '&gt;';   break;
+      default:                    continue;
+    }
+    if (lastIndex !== i) result += html.substring(lastIndex, i);
+    lastIndex = i + 1;
+    result += escape;
+  }
+  if (lastIndex !== i) return result + html.substring(lastIndex, i);
+  else                 return result;
 }

--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ function escapeHtml(html) {
   for (i = regexResult.index; i < html.length; i++) {
     switch (html.charCodeAt(i)) {
       case 34: escape = '&quot;'; break;
-      case 39: escape = '&#39;';  break;
       case 38: escape = '&amp;';  break;
+      case 39: escape = '&#39;';  break;
       case 60: escape = '&lt;';   break;
       case 62: escape = '&gt;';   break;
       default:                    continue;


### PR DESCRIPTION
Implementation adapted from Jade's. About 2-8x faster.

Benchmark:

```js
var Benchmark = require('benchmark');
var suite = new Benchmark.Suite;

function oldEscape(html) {
  return String(html)
    .replace(/&/g, '&amp;')
    .replace(/"/g, '&quot;')
    .replace(/'/g, '&#39;')
    .replace(/</g, '&lt;')
    .replace(/>/g, '&gt;');
}

var matchHtml = /["'&<>]/;

function newEscape(html) {
  html = '' + html;
  var regexResult = matchHtml.exec(html);
  if (!regexResult) return html;

  var result = '';
  var i, lastIndex = 0, escape;
  for (i = regexResult.index; i < html.length; i++) {
    switch (html.charCodeAt(i)) {
      case 34: escape = '&quot;'; break;
      case 39: escape = '&#39;';  break;
      case 38: escape = '&amp;';  break;
      case 60: escape = '&lt;';   break;
      case 62: escape = '&gt;';   break;
      default:                    continue;
    }
    if (lastIndex !== i) result += html.substring(lastIndex, i);
    lastIndex = i + 1;
    result += escape;
  }
  if (lastIndex !== i) return result + html.substring(lastIndex, i);
  else                 return result;
}

// add tests
suite.add('no escape – old', function() {
  oldEscape('Hello World!');
}).add('no escape – new', function() {
  newEscape('Hello World!');
}).add('light escape – old', function() {
  oldEscape('Hello & World!');
}).add('light escape – new', function() {
  newEscape('Hello & World!');
}).add('heavy escape – old', function() {
  oldEscape('\'>\'""&>h<e>&<y>');
}).add('heavy escape – new', function() {
  newEscape('\'>\'""&>h<e>&<y>');
}).on('cycle', function (event) {
  console.log(String(event.target));
}).run()
```

```
$ node ./j
no escape – old x 1,553,747 ops/sec ±1.55% (93 runs sampled)
no escape – new x 13,234,354 ops/sec ±0.77% (98 runs sampled)
light escape – old x 1,325,111 ops/sec ±1.41% (98 runs sampled)
light escape – new x 3,418,685 ops/sec ±0.59% (98 runs sampled)
heavy escape – old x 744,608 ops/sec ±0.66% (96 runs sampled)
heavy escape – new x 2,237,829 ops/sec ±0.58% (92 runs sampled)
```

```js
$ node -pe process.versions
{ http_parser: '2.5.0',
  node: '3.2.0',
  v8: '4.4.63.26',
  uv: '1.6.1',
  zlib: '1.2.8',
  ares: '1.10.1-DEV',
  modules: '45',
  openssl: '1.0.2d' }
```