### PR TITLE
perf: Do not unconditionally cast to String

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,12 +30,11 @@ module.exports = escapeHtml;
  * @public
  */
 
-function escapeHtml(string) {
-  var str = String(string);
+function escapeHtml(str) {
   var match = matchHtmlRegExp.exec(str);
 
   if (!match) {
-    return str;
+    return '' + str;
   }
 
   var escape;


### PR DESCRIPTION
Also use a faster method to cast to String.

According to ECMAScript 5.1:
- `RegExp.prototype.exec` calls the internal operation `ToString` on its argument ([15.10.6.2 RegExp.prototype.exec(string)](https://es5.github.io/#x15.10.6.2))
- `String(string)` is equivalent to the `ToString` internal operation ([15.5.1.1 String ( [ value ] )](https://es5.github.io/#x15.5.1.1))
- `'' + string` is equivalent to `ToString(ToPrimitive('')) + ToString(ToPrimitive(string))` internal operation, which is equivalent to `ToString(string)` ([11.6.1 The Addition operator ( + )](https://es5.github.io/#x11.6.1))

Thus the behavior should be identical.